### PR TITLE
chore(CD): rebuild and deploy the site every 12h

### DIFF
--- a/.github/workflows/scheduled-deploys.yml
+++ b/.github/workflows/scheduled-deploys.yml
@@ -1,0 +1,26 @@
+name: Trigger Site Rebuild on a CRON Schedule
+
+on:
+  schedule: 
+    - cron: '1 */12 * * *' # "At minute 1 past every 12th hour." (see https://crontab.guru)
+permissions: 
+  contents: write
+jobs:
+  trigger-deploy:
+    # prevents this action from running on forks
+    if: github.repository == 'Roma-JS/roma-js-on-astro'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          ref: 'release'
+          fetch-depth: 0
+      - name: Update site-deploy.yml
+        run: |
+          printf 'date: %s\ncid: %s\n' "$(date)" "$(git rev-parse --short HEAD)" > site-deploy.yml
+      - name: Commit changes
+        run: |
+          git add site-deploy.yml && git commit -m "cron-deploy $(date)"
+#         git push origin release --force 
+    

--- a/.github/workflows/scheduled-deploys.yml
+++ b/.github/workflows/scheduled-deploys.yml
@@ -3,8 +3,6 @@ name: Trigger Site Rebuild on a CRON Schedule
 on:
   schedule: 
     - cron: '1 */12 * * *' # "At minute 1 past every 12th hour." (see https://crontab.guru)
-permissions: 
-  contents: write
 jobs:
   trigger-deploy:
     # prevents this action from running on forks
@@ -15,12 +13,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: 'release'
-          fetch-depth: 0
+      - name: Setup environoment
+        run: |
+          git config user.name 'cronjob-deploy'
+          git config user.email 'noreply@romajs.org'       
+          export GIT_CID_DATE="$(date)" GIT_CID_ID="$(git rev-parse --short HEAD)"
       - name: Update site-deploy.yml
         run: |
-          printf 'date: %s\ncid: %s\n' "$(date)" "$(git rev-parse --short HEAD)" > site-deploy.yml
-      - name: Commit changes
+          printf 'date: %s\ncid: %s\n' "$GIT_CID_DATE" "$GIT_CID_ID" > site-deploy.yml
+      - name: Commit and push changes
         run: |
-          git add site-deploy.yml && git commit -m "cron-deploy $(date)"
-#         git push origin release --force 
-    
+          git add site-deploy.yml
+          git commit -m "cron-deploy 🚀 of $GIT_CID_ID at $GIT_CID_DATE"
+#         git push origin release


### PR DESCRIPTION
Adds cron job that rebuilds the site every 12h.

Note that the [trigger of the deploy pipeline](https://github.com/Roma-JS/roma-js-on-astro/compare/main...FaberVitale:feat/trigger-deploy-in-cron-job?expand=1#diff-d2d061c1047dc22d597831934d17b958e48ef5ab303a768e3eca14930236789eR25) is currently disabled.
