### PR TITLE
fix: expired slack link

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ PUBLIC_TWITTER_HANDLE="@roma_js"
 PUBLIC_TWITTER_PROFILE_HREF="https://twitter.com/roma_js"
 PUBLIC_FACEBOOK_PAGE_HREF="https://www.facebook.com/romajs.org"
 PUBLIC_YOUTUBE_PAGE_HREF="https://www.youtube.com/channel/UCFm8OPi5USbFybw9SaTLxeA"
-PUBLIC_SLACK_INVITE_HREF="https://join.slack.com/t/romajs/shared_invite/zt-1me295zww-dZIuVFshAdVpY4XX~PfNTw"
+PUBLIC_SLACK_INVITE_HREF="https://join.slack.com/t/romajs/shared_invite/zt-1pcgmehxd-8fnXmra8OjOCGVeBnNtZPg"
 PUBLIC_GITHUB_PROFILE_HREF="https://github.com/Roma-JS"
 # see https://giscus.app/it
 PUBLIC_GISCUS_REPO_NAME="Roma-JS/roma-js-on-astro"


### PR DESCRIPTION
### Notable changes

adds brand new slack invite that replaces an expired one.

Closes #28
