### PR TITLE
feat: add about page headless endpoints

### DIFF
--- a/src/@types/about.d.ts
+++ b/src/@types/about.d.ts
@@ -1,0 +1,13 @@
+export interface AboutInfo {
+  title: string;
+  description: string;
+  createdAt: Date;
+  author: string;
+  categories: string[];
+  layout: string;
+  lang: string;
+}
+
+export interface AboutContent extends AboutInfo {
+  content: string;
+}

--- a/src/pages/api/about/en.json.ts
+++ b/src/pages/api/about/en.json.ts
@@ -1,0 +1,15 @@
+import type { AboutContent, AboutInfo } from '../../../@types/about';
+import type { MarkdownInstance } from 'astro';
+
+type Content = MarkdownInstance<AboutInfo>;
+
+export async function getItAboutContent(): Promise<Readonly<AboutContent>> {
+  const info = await import.meta.glob('../../*/about.md');
+  const content = (await info['../../en/about.md']()) as Content;
+
+  return { ...content.frontmatter, content: content.compiledContent() };
+}
+
+export async function GET() {
+  return new Response(JSON.stringify(await getItAboutContent()));
+}

--- a/src/pages/api/about/it.json.ts
+++ b/src/pages/api/about/it.json.ts
@@ -1,0 +1,15 @@
+import type { AboutContent, AboutInfo } from '../../../@types/about';
+import type { MarkdownInstance } from 'astro';
+
+type Content = MarkdownInstance<AboutInfo>;
+
+export async function getItAboutContent(): Promise<Readonly<AboutContent>> {
+  const info = await import.meta.glob('../../*/about.md');
+  const content = (await info['../../it/about.md']()) as Content;
+
+  return { ...content.frontmatter, content: content.compiledContent() };
+}
+
+export async function GET() {
+  return new Response(JSON.stringify(await getItAboutContent()));
+}


### PR DESCRIPTION
This PR add the headless endpoints for the about page, as describe in #15 

Closes #15 