### PR TITLE
fix: language switch not working on upcoming and past events

### DIFF
--- a/src/layouts/PastEvents.astro
+++ b/src/layouts/PastEvents.astro
@@ -9,7 +9,7 @@ import { BuildInfo } from '@components/BuildInfo/BuildInfo';
 import { Navbar } from '@components/Navbar/Navbar';
 import { SlantedHeader } from '@components/SlantedHeader/SlantedHeader';
 import { changeLanguage } from 'i18next';
-import { getCanonicalURL, aboutUrlMap, navbarLinks } from 'utils/routing';
+import { getCanonicalURL, navbarLinks, pastEventsUrlMap } from 'utils/routing';
 import { SocialLinksList } from '@components/SocialLinksList/SocialLinksList';
 import type { Lang } from '@i18n/types';
 import { getNavbarMessages } from '@components/Navbar/helpers';
@@ -53,7 +53,7 @@ changeLanguage(lang);
       <Navbar
         client:load
         lang={lang}
-        urlMap={aboutUrlMap}
+        urlMap={pastEventsUrlMap}
         relativePageUrl={relativePageUrl}
         messages={getNavbarMessages()}
       />
@@ -66,7 +66,7 @@ changeLanguage(lang);
         <BrandLogo class='logo-small' />
       </SlantedHeader>
       <div class="main-content">
-        <EventsList events={scheduledEvents}  lang={lang} />
+        <EventsList events={scheduledEvents} lang={lang} />
         <slot />
         <Pagination url={page.url} lang={lang} />
       </div>

--- a/src/layouts/UpcomingEvents.astro
+++ b/src/layouts/UpcomingEvents.astro
@@ -8,7 +8,11 @@ import { BuildInfo } from '@components/BuildInfo/BuildInfo';
 import { Navbar } from '@components/Navbar/Navbar';
 import { SlantedHeader } from '@components/SlantedHeader/SlantedHeader';
 import { changeLanguage } from 'i18next';
-import { getCanonicalURL, aboutUrlMap, navbarLinks } from 'utils/routing';
+import {
+  getCanonicalURL,
+  navbarLinks,
+  upcomingEventsUrlMap,
+} from 'utils/routing';
 import { SocialLinksList } from '@components/SocialLinksList/SocialLinksList';
 import type { Lang } from '@i18n/types';
 import { getNavbarMessages } from '@components/Navbar/helpers';
@@ -48,7 +52,7 @@ changeLanguage(lang);
       <Navbar
         client:load
         lang={lang}
-        urlMap={aboutUrlMap}
+        urlMap={upcomingEventsUrlMap}
         relativePageUrl={relativePageUrl}
         messages={getNavbarMessages()}
       />

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -46,6 +46,11 @@ export const hpUrlMap: Readonly<Record<Lang, string>> = {
   en: routes.en.home,
 };
 
+export const upcomingEventsUrlMap: Readonly<Record<Lang, string>> = {
+  it: routes.it['prossimi eventi'],
+  en: routes.en['upcoming events'],
+};
+
 export const aboutUrlMap: Readonly<Record<Lang, string>> = {
   it: routes.it.about,
   en: routes.en.about,

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -51,6 +51,11 @@ export const upcomingEventsUrlMap: Readonly<Record<Lang, string>> = {
   en: routes.en['upcoming events'],
 };
 
+export const pastEventsUrlMap: Readonly<Record<Lang, string>> = {
+  it: routes.it['eventi passati'],
+  en: routes.en['past events'],
+};
+
 export const aboutUrlMap: Readonly<Record<Lang, string>> = {
   it: routes.it.about,
   en: routes.en.about,


### PR DESCRIPTION
This PR fixes the language switch on UpcomingEvents and PastEvents pages.

Fixes #85 