### PR TITLE
Fix 84/incorrect site name

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jsdom": "^24.1.0",
     "lint-staged": "^15.2.7",
     "mustache": "^4.2.0",
-    "prettier": "2.7.1",
+    "prettier": "2.8.7",
     "prompts": "^2.4.2",
     "sass": "^1.77.8",
     "tiny-invariant": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.3
-        version: 0.9.3(prettier@2.7.1)(typescript@5.5.4)
+        version: 0.9.3(prettier@2.8.7)(typescript@5.5.4)
       '@astrojs/rss':
         specifier: ^4.0.7
         version: 4.0.7
@@ -79,8 +79,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       prettier:
-        specifier: 2.7.1
-        version: 2.7.1
+        specifier: 2.8.7
+        version: 2.8.7
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -2222,11 +2222,6 @@ packages:
     resolution: {integrity: sha512-gYBeFTZLu055D8Vv3cSPox/0iTPtkzxpLroSYYA7WXgRi31WCJ51Uyl8ZiPeUUjyvs2MBzK+S8v9JVUgHU/Sqw==}
     engines: {node: '>=18.12'}
 
-  prettier@2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   prettier@2.8.7:
     resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
@@ -3045,9 +3040,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@astrojs/check@0.9.3(prettier@2.7.1)(typescript@5.5.4)':
+  '@astrojs/check@0.9.3(prettier@2.8.7)(typescript@5.5.4)':
     dependencies:
-      '@astrojs/language-server': 2.14.1(prettier@2.7.1)(typescript@5.5.4)
+      '@astrojs/language-server': 2.14.1(prettier@2.8.7)(typescript@5.5.4)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       kleur: 4.1.5
@@ -3061,7 +3056,7 @@ snapshots:
 
   '@astrojs/internal-helpers@0.4.1': {}
 
-  '@astrojs/language-server@2.14.1(prettier@2.7.1)(typescript@5.5.4)':
+  '@astrojs/language-server@2.14.1(prettier@2.8.7)(typescript@5.5.4)':
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/yaml2ts': 0.2.1
@@ -3076,14 +3071,14 @@ snapshots:
       volar-service-css: 0.0.61(@volar/language-service@2.4.0)
       volar-service-emmet: 0.0.61(@volar/language-service@2.4.0)
       volar-service-html: 0.0.61(@volar/language-service@2.4.0)
-      volar-service-prettier: 0.0.61(@volar/language-service@2.4.0)(prettier@2.7.1)
+      volar-service-prettier: 0.0.61(@volar/language-service@2.4.0)(prettier@2.8.7)
       volar-service-typescript: 0.0.61(@volar/language-service@2.4.0)
       volar-service-typescript-twoslash-queries: 0.0.61(@volar/language-service@2.4.0)
       volar-service-yaml: 0.0.61(@volar/language-service@2.4.0)
       vscode-html-languageservice: 5.3.0
       vscode-uri: 3.0.8
     optionalDependencies:
-      prettier: 2.7.1
+      prettier: 2.8.7
     transitivePeerDependencies:
       - typescript
 
@@ -5409,10 +5404,7 @@ snapshots:
       find-yarn-workspace-root2: 1.2.16
       which-pm: 3.0.0
 
-  prettier@2.7.1: {}
-
-  prettier@2.8.7:
-    optional: true
+  prettier@2.8.7: {}
 
   prismjs@1.29.0: {}
 
@@ -6047,12 +6039,12 @@ snapshots:
     optionalDependencies:
       '@volar/language-service': 2.4.0
 
-  volar-service-prettier@0.0.61(@volar/language-service@2.4.0)(prettier@2.7.1):
+  volar-service-prettier@0.0.61(@volar/language-service@2.4.0)(prettier@2.8.7):
     dependencies:
       vscode-uri: 3.0.8
     optionalDependencies:
       '@volar/language-service': 2.4.0
-      prettier: 2.7.1
+      prettier: 2.8.7
 
   volar-service-typescript-twoslash-queries@0.0.61(@volar/language-service@2.4.0):
     dependencies:

--- a/src/components/Navbar/helpers.ts
+++ b/src/components/Navbar/helpers.ts
@@ -10,7 +10,9 @@ const l10nKeys = [
   'enWebsite',
 ] as const;
 
-export type NavbarMessages = Readonly<Record<typeof l10nKeys[number], string>>;
+export type NavbarMessages = Readonly<
+  Record<(typeof l10nKeys)[number], string>
+>;
 
 /**
  * Do not use this function inside a component,

--- a/src/components/SiteNameStructuredData.astro
+++ b/src/components/SiteNameStructuredData.astro
@@ -1,0 +1,14 @@
+---
+// The structured data used in the google search results
+// See https://developers.google.com/search/docs/appearance/site-names#technical-guidelines
+// for more infos.
+---
+
+<script type="application/ld+json" is:inline>
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "RomaJS",
+    "url": "https://romajs.org/"
+  }
+</script>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,4 +1,4 @@
-import type { I18nRouteParams } from './types';
+import type { I18nRouteParams, Lang } from './types';
 import { t as i18nextTranslate } from 'i18next';
 import type { TOptions } from 'i18next';
 import type L10nMessages from '../../public/locales/it/translation.json';
@@ -10,7 +10,16 @@ export const i18nLang = Object.freeze({
   en: {
     locale: 'en-US',
   },
-} as const);
+} as const satisfies Readonly<Record<Lang, { locale: string }>>);
+
+export function assertValidLang(value: unknown): asserts value is Lang {
+  const validLangs = getI18nRouteParams().map(({ lang }) => lang);
+  if (!validLangs.some((lang) => lang === value)) {
+    throw new TypeError(
+      `assertion failed, expected valid lang (it, en), got ${value}`
+    );
+  }
+}
 
 export function getI18nRouteParams(): I18nRouteParams[] {
   return Object.entries(i18nLang).map(([lang]) => ({

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,6 +1,6 @@
 ---
 import HpLayout from '@layouts/Hp.astro';
-import { getI18nRouteParams } from '@i18n/config';
+import { assertValidLang, getI18nRouteParams } from '@i18n/config';
 import { getEnHpContent } from '../api/hp/en.json';
 import { getHpItContent } from '../api/hp/it.json';
 import { hpUrlMap } from 'utils/routing';
@@ -16,7 +16,10 @@ export async function getStaticPaths() {
 }
 
 function getProp<Key extends keyof Props>(key: Key): Props[Key] {
-  return Astro.props[key] ?? (Astro.params[key as keyof typeof Astro.params] as Props[Key]);
+  return (
+    Astro.props[key] ??
+    (Astro.params[key as keyof typeof Astro.params] as Props[Key])
+  );
 }
 
 function getContentByLang(lang: Lang) {
@@ -34,6 +37,7 @@ function getContentByLang(lang: Lang) {
 }
 
 const lang = getProp('lang');
+assertValidLang(lang);
 const { title, description, sections } = await getContentByLang(lang);
 const permalink = Astro.props.permalink;
 ---
@@ -45,4 +49,12 @@ const permalink = Astro.props.permalink;
   urlMap={hpUrlMap}
   sections={sections}
   permalink={permalink}
-/>
+>
+  <Fragment slot="head">
+    {
+      lang === 'it' && (
+        <link rel="canonical" href={process.env.PUBLIC_SITE_URL} />
+      )
+    }
+  </Fragment>
+</HpLayout>

--- a/src/pages/api/about/en.json.ts
+++ b/src/pages/api/about/en.json.ts
@@ -4,7 +4,7 @@ import type { MarkdownInstance } from 'astro';
 type Content = MarkdownInstance<AboutInfo>;
 
 export async function getItAboutContent(): Promise<Readonly<AboutContent>> {
-  const info = await import.meta.glob('../../*/about.md');
+  const info = import.meta.glob('../../*/about.md');
   const content = (await info['../../en/about.md']()) as Content;
 
   return { ...content.frontmatter, content: content.compiledContent() };

--- a/src/pages/api/about/it.json.ts
+++ b/src/pages/api/about/it.json.ts
@@ -4,7 +4,7 @@ import type { MarkdownInstance } from 'astro';
 type Content = MarkdownInstance<AboutInfo>;
 
 export async function getItAboutContent(): Promise<Readonly<AboutContent>> {
-  const info = await import.meta.glob('../../*/about.md');
+  const info = import.meta.glob('../../*/about.md');
   const content = (await info['../../it/about.md']()) as Content;
 
   return { ...content.frontmatter, content: content.compiledContent() };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import { getHpItContent } from './api/hp/it.json';
 import { hpUrlMap } from 'utils/routing';
 import type { Lang } from '@i18n/types';
 import { changeLanguage } from 'i18next';
+import SiteNameStructuredData from '@components/SiteNameStructuredData.astro';
 
 const lang: Lang = 'it';
 changeLanguage(lang);
@@ -18,4 +19,8 @@ const permalink = Astro.props.permalink;
   urlMap={hpUrlMap}
   sections={sections}
   permalink={permalink}
-/>
+>
+  <Fragment slot="head">
+    <SiteNameStructuredData />
+  </Fragment>
+</HpLayout>

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -108,5 +108,5 @@ export const socialLinks = {
   linkedin: {
     href: import.meta.env.PUBLIC_LINKEDIN_PROFILE_HREF,
     iconHref: linkedinIcon,
-  }
+  },
 } as const;


### PR DESCRIPTION
### Description

Closes #84, hopefully 🤞.

Adds website name structured data in the homepage romajs.org, see 94b745d71d7f7a738c7a1d0d2016eb03f6230c35

### Other changes

- add [canonical](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) link in romajs.org/it
- bump prettier version
- fix small lint issues
