### PR TITLE
fix: using strict equality in generateLinkRelAlternateProps method in…

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -70,7 +70,7 @@ export function generateLinkRelAlternateProps(url: URL): RelAlternateProps[] {
   lang = lang.toLowerCase();
 
   for (const hreflang of Object.keys(i18nLang)) {
-    if (hreflang !== lang) {
+    if (hreflang === lang) {
       const altUrl = new URL(url);
 
       altUrl.pathname = `/${hreflang}${altUrl.pathname.slice(


### PR DESCRIPTION
if I understood correctly @FaberVitale, you make a for loop on the back-end side to generate the links in the header, so you only have to add the parameters in **i18nLang** and  **routing.ts** files; so you gave an order on both sides (first: it, second: en).

But the for loop that must generate the links, acts only on _hreflang_.
So what happens... **lang** does not switch its value, while **hreflang** does... and since you say that the two values ​​must not be strictly equal, the code generates incorrect links by inverting the values ​​of "it" and "en".

So the fix, without having to do a total refactoring of the method (which perhaps could also be done) is simply to change the operator with strictly equality.

I'm posting pictures with some tests in localhost after the fix:

**eventi-passati/1/**
![image](https://github.com/user-attachments/assets/e6ab02f9-549e-442c-8c17-a0595ff888c6)

**past-events/1/**
![image](https://github.com/user-attachments/assets/f6a9e129-f193-4daa-8e8d-e55c1c517c07)

**prossimi-eventi/**
![image](https://github.com/user-attachments/assets/216b3199-491e-40ff-8e0b-29791a278a7d)

**upcoming-events**
![image](https://github.com/user-attachments/assets/201f7f15-ea6f-4abe-bad0-a4393fa76fbe)
