### PR TITLE
chore: hide feb 19 from upcoming events

### DIFF
--- a/.env
+++ b/.env
@@ -23,4 +23,4 @@ MEETUP_GROUP_ID='RomaJS'
 
 # See https://github.com/Roma-JS/roma-js-on-astro/issues/80
 # It's a comma-separated list. We use ISO LL format: 08 -> August
-PUBLIC_MONTHS_WITHOUT_GENERATED_UPCOMING_EVENTS='08'
+PUBLIC_MONTHS_WITHOUT_GENERATED_UPCOMING_EVENTS='02,08'


### PR DESCRIPTION
Hides Feb 19 from the list of upcoming events

<img width="853" alt="Screenshot 2025-01-29 at 21 04 41" src="https://github.com/user-attachments/assets/1494116a-01f6-4ae8-aa19-443adfcff51e" />
