### PR TITLE
fix(GH-90): invalid link rel alternate for upcoming pages

### DIFF
--- a/e2e-tests/previous-events.e2e.test.ts
+++ b/e2e-tests/previous-events.e2e.test.ts
@@ -1,12 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import { expectH1, expectWellFormedPage } from './shared-e2e-tests';
+
+const urlMap = {
+  it: '/it/eventi-passati/1',
+  en: '/en/past-events/1',
+};
 
 test('italian previous-events page is well formed', async ({ page }) => {
   await page.goto('./it/eventi-passati/1/');
   const lang = 'it';
 
   await Promise.all([
-    expectWellFormedPage(page, lang, null),
+    expectWellFormedPage(page, lang, urlMap),
     expectH1(page, /Eventi passati/i),
   ]);
 });
@@ -16,7 +21,7 @@ test('english previous-events page is well formed', async ({ page }) => {
   const lang = 'en';
 
   await Promise.all([
-    expectWellFormedPage(page, lang, null),
+    expectWellFormedPage(page, lang, urlMap),
     expectH1(page, /Past Events/i),
   ]);
 });

--- a/e2e-tests/upcoming-events.e2e.test.ts
+++ b/e2e-tests/upcoming-events.e2e.test.ts
@@ -1,12 +1,17 @@
 import { test } from '@playwright/test';
 import { expectH1, expectWellFormedPage } from './shared-e2e-tests';
 
+const urlMap = {
+  it: '/it/prossimi-eventi',
+  en: '/en/upcoming-events',
+};
+
 test('italian upcoming-events page is well formed', async ({ page }) => {
   await page.goto('./it/prossimi-eventi/');
   const lang = 'it';
 
   await Promise.all([
-    expectWellFormedPage(page, lang, null),
+    expectWellFormedPage(page, lang, urlMap),
     expectH1(page, /Prossimi eventi/i),
   ]);
 });
@@ -16,7 +21,7 @@ test('english upcoming-events page is well formed', async ({ page }) => {
   const lang = 'en';
 
   await Promise.all([
-    expectWellFormedPage(page, lang, null),
+    expectWellFormedPage(page, lang, urlMap),
     expectH1(page, /upcoming events/i),
   ]);
 });

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,7 +1,9 @@
 ---
 import { generateLinkRelAlternateProps } from '@i18n/config';
+import type { Lang } from '@i18n/types';
 import { getCanonicalURL } from 'utils/routing';
 export interface Props {
+  lang: Lang;
   title: string;
   description: string;
   permalink?: string;
@@ -9,13 +11,18 @@ export interface Props {
 
 const canonicalURL = getCanonicalURL(Astro);
 
-const { title, description, permalink = canonicalURL } = Astro.props as Props;
+const {
+  title,
+  description,
+  permalink = canonicalURL,
+  lang,
+} = Astro.props as Props;
 
 const ogImage = new URL(canonicalURL.origin);
 ogImage.pathname = '/assets/og-img.png';
 
 // @see https://developers.google.com/search/docs/advanced/crawling/localized-versions
-const linkRelAlternateProps = generateLinkRelAlternateProps(canonicalURL);
+const linkRelAlternateProps = generateLinkRelAlternateProps(lang, canonicalURL);
 ---
 
 <meta charset="utf-8" />

--- a/src/components/Navbar/helpers.ts
+++ b/src/components/Navbar/helpers.ts
@@ -8,6 +8,11 @@ const l10nKeys = [
   'mainSiteNav',
   'itWebsite',
   'enWebsite',
+  'upcomingEvents',
+  'pastEvents',
+  'homepage',
+  'aboutPage',
+  'blog',
 ] as const;
 
 export type NavbarMessages = Readonly<

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,5 +1,5 @@
 import type { I18nRouteParams, Lang } from './types';
-import { hpUrlMap } from 'utils/routing';
+import { routes, type RouteKey } from 'utils/routing';
 
 export const i18nLang = Object.freeze({
   it: {
@@ -25,17 +25,12 @@ export function getI18nRouteParams(): I18nRouteParams[] {
   }));
 }
 
-const routeParamsRegex = new RegExp(
-  `^(?<leadingSlash>\/?)(?<lang>${Object.keys(i18nLang).join(
-    '|'
-  )})(?<rest>.*)$`,
-  'i'
-);
-
 export interface RelAlternateProps {
   href: string;
   hreflang: string;
 }
+
+const trimTrailingSlash = (path: string) => path.replace(/\/+$/g, '');
 
 /**
  * Generates a list `link[rel="alternate"]` attributes given input url.
@@ -43,41 +38,32 @@ export interface RelAlternateProps {
  * @returns
  * @see https://developers.google.com/search/docs/advanced/crawling/localized-versions
  */
-export function generateLinkRelAlternateProps(url: URL): RelAlternateProps[] {
+export function generateLinkRelAlternateProps(
+  pageLang: Lang,
+  url: URL
+): RelAlternateProps[] {
   const output: RelAlternateProps[] = [];
+  const pathnameToSearch = trimTrailingSlash(url.pathname);
 
-  if (/^\/?$/.test(url.pathname)) {
-    // is index page ?
-    return [
-      {
-        href: hpUrlMap.en,
-        hreflang: 'en',
-      },
-    ];
-  }
+  const routeKey = Object.entries(routes[pageLang]).find(
+    ([, pathname]) => pathnameToSearch === trimTrailingSlash(pathname)
+  )?.[0] as RouteKey;
 
-  const result = routeParamsRegex.exec(url.pathname);
+  if (routeKey) {
+    for (const [lang, langRoutes] of Object.entries(routes)) {
+      if (lang === pageLang) {
+        continue;
+      }
 
-  if (!result || !result.groups) {
-    return output;
-  }
+      const relativeUrl: string | undefined =
+        langRoutes[routeKey as keyof typeof langRoutes];
 
-  let { leadingSlash, lang } = result.groups;
-
-  lang = lang.toLowerCase();
-
-  for (const hreflang of Object.keys(i18nLang)) {
-    if (hreflang !== lang) {
-      const altUrl = new URL(url);
-
-      altUrl.pathname = `/${hreflang}${altUrl.pathname.slice(
-        leadingSlash.length + lang.length
-      )}`;
-
-      output.push({
-        hreflang,
-        href: altUrl.href,
-      });
+      if (typeof relativeUrl === 'string') {
+        output.push({
+          hreflang: lang,
+          href: new URL(relativeUrl, import.meta.env.PUBLIC_SITE_URL).href,
+        });
+      }
     }
   }
 

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -27,5 +27,10 @@
   "itWebsite": "Italian website",
   "enWebsite": "English website",
   "skipToMainContent": "Skip to main content",
-  "talkSpeaker": "Speaker"
+  "talkSpeaker": "Speaker",
+  "upcomingEvents": "Upcoming events",
+  "pastEvents": "Previous events",
+  "homepage": "home",
+  "aboutPage": "about",
+  "blog": "blog"
 }

--- a/src/i18n/translations/it.json
+++ b/src/i18n/translations/it.json
@@ -27,5 +27,10 @@
   "itWebsite": "Sito in Italiano",
   "enWebsite": "Sito in Inglese",
   "skipToMainContent": "Vai al contenuto principale",
-  "talkSpeaker": "Speaker"
+  "talkSpeaker": "Speaker",
+  "upcomingEvents": "Prossimi eventi",
+  "pastEvents": "Eventi passati",
+  "homepage": "home",
+  "aboutPage": "about",
+  "blog": "blog"
 }

--- a/src/layouts/About.astro
+++ b/src/layouts/About.astro
@@ -31,7 +31,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -53,7 +53,7 @@ const breadcrumMessages = Object.fromEntries(
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/BlogPostList.astro
+++ b/src/layouts/BlogPostList.astro
@@ -56,7 +56,7 @@ const breadcrumMessages = Object.fromEntries(
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/CategoriesList.astro
+++ b/src/layouts/CategoriesList.astro
@@ -38,7 +38,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/Event.astro
+++ b/src/layouts/Event.astro
@@ -51,7 +51,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/Hp.astro
+++ b/src/layouts/Hp.astro
@@ -47,7 +47,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/PastEvents.astro
+++ b/src/layouts/PastEvents.astro
@@ -41,7 +41,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/layouts/UpcomingEvents.astro
+++ b/src/layouts/UpcomingEvents.astro
@@ -40,7 +40,7 @@ const l10n = await createTranslate(lang);
 
 <html lang={lang} class="rmjs-yellow-black-theme">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead lang={lang} title={title} description={description} />
     <slot name="head" />
     <ClientRouter />
   </head>

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -8,30 +8,44 @@ import discordIcon from 'media/social/discord.svg';
 import linkedinIcon from 'media/social/linkedin.svg';
 import type { AstroGlobal } from 'astro';
 
+const createPageRoute = (relativeUrl: string) =>
+  new URL(relativeUrl, import.meta.env.PUBLIC_SITE_URL).pathname;
+
+export type RouteKey =
+  | 'homepage'
+  | 'upcomingEvents'
+  | 'pastEvents'
+  | 'blog'
+  | 'aboutPage';
+
+const itRoutes = {
+  homepage: createPageRoute('/'),
+  upcomingEvents: createPageRoute('/it/prossimi-eventi'),
+  pastEvents: createPageRoute('/it/eventi-passati/1'),
+  blog: createPageRoute('/blog'),
+  aboutPage: createPageRoute('/it/about'),
+} as const satisfies Partial<Record<RouteKey, string>>;
+
+const enRoutes = {
+  homepage: createPageRoute('/en'),
+  upcomingEvents: createPageRoute('/en/upcoming-events'),
+  pastEvents: createPageRoute('/en/past-events/1'),
+  aboutPage: createPageRoute('/en/about'),
+} as const satisfies Partial<Record<RouteKey, string>>;
+
 export const routes = {
-  it: {
-    home: import.meta.env.PUBLIC_URL_BASE + '/',
-    'prossimi eventi': import.meta.env.PUBLIC_URL_BASE + '/it/prossimi-eventi',
-    'eventi passati': import.meta.env.PUBLIC_URL_BASE + '/it/eventi-passati/1',
-    blog: import.meta.env.PUBLIC_URL_BASE + '/blog',
-    about: import.meta.env.PUBLIC_URL_BASE + '/it/about',
-  },
-  en: {
-    home: import.meta.env.PUBLIC_URL_BASE + '/en',
-    'upcoming events': import.meta.env.PUBLIC_URL_BASE + '/en/upcoming-events',
-    'past events': import.meta.env.PUBLIC_URL_BASE + '/en/past-events/1',
-    about: import.meta.env.PUBLIC_URL_BASE + '/en/about',
-  },
-} as const;
+  it: itRoutes,
+  en: enRoutes,
+} as const satisfies Record<Lang, Partial<Record<RouteKey, string>>>;
 
 export const breadcrumbLinks = {
   it: {
-    home: routes.it.home,
+    home: routes.it.homepage,
     blog: routes.it.blog,
   },
   en: {
-    home: routes.en.home,
-    about: routes.en.about,
+    home: routes.en.homepage,
+    about: routes.en.aboutPage,
   },
 };
 
@@ -43,23 +57,23 @@ export const navbarLinks: Readonly<Record<Lang, Record<string, string>>> = {
 export const categoryPageUrl = navbarLinks.it.blog + '/category';
 
 export const hpUrlMap: Readonly<Record<Lang, string>> = {
-  it: routes.it.home,
-  en: routes.en.home,
+  it: routes.it.homepage,
+  en: routes.en.homepage,
 };
 
 export const upcomingEventsUrlMap: Readonly<Record<Lang, string>> = {
-  it: routes.it['prossimi eventi'],
-  en: routes.en['upcoming events'],
+  it: routes.it.upcomingEvents,
+  en: routes.en.upcomingEvents,
 };
 
 export const pastEventsUrlMap: Readonly<Record<Lang, string>> = {
-  it: routes.it['eventi passati'],
-  en: routes.en['past events'],
+  it: routes.it.pastEvents,
+  en: routes.en.pastEvents,
 };
 
 export const aboutUrlMap: Readonly<Record<Lang, string>> = {
-  it: routes.it.about,
-  en: routes.en.about,
+  it: routes.it.aboutPage,
+  en: routes.en.aboutPage,
 };
 
 export function preventSelfNavigation(


### PR DESCRIPTION
Fixes #90

The `generateLinkRelAlternateProps` algorithm has been rewritten in order to not be based on an heuristic but on a specific logic:

Pages with the same `RouteKey` in the routes object are picked as alternate links. 

### Next steps

The algorithm currently doesn't support pagination, this will be addressed in another PR.


### Other changes

Updated e2e tests to assert that alternate links are created correctly.